### PR TITLE
Naming Change and Equatable Exclusion

### DIFF
--- a/JSONSwiftGenerator.xcodeproj/project.pbxproj
+++ b/JSONSwiftGenerator.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		26FA93221E674F5C00A5DF05 /* DataRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FA93211E674F5C00A5DF05 /* DataRouter.swift */; };
 		26FA93241E67531800A5DF05 /* LaunchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FA93231E67531800A5DF05 /* LaunchRouter.swift */; };
 		26FAFDAC1E6721FE00609139 /* RecognizedArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FAFDAB1E6721FE00609139 /* RecognizedArguments.swift */; };
+		AF5A59D71E69BFDE009F531E /* String+CamelCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5A59D61E69BFDE009F531E /* String+CamelCase.swift */; };
+		AF5A59D91E69C110009F531E /* Character+Uppercase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5A59D81E69C110009F531E /* Character+Uppercase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -46,6 +48,8 @@
 		26FA93231E67531800A5DF05 /* LaunchRouter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LaunchRouter.swift; path = Router/LaunchRouter.swift; sourceTree = "<group>"; };
 		26FAFDA91E671B0600609139 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		26FAFDAB1E6721FE00609139 /* RecognizedArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RecognizedArguments.swift; path = IO/RecognizedArguments.swift; sourceTree = "<group>"; };
+		AF5A59D61E69BFDE009F531E /* String+CamelCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+CamelCase.swift"; sourceTree = "<group>"; };
+		AF5A59D81E69C110009F531E /* Character+Uppercase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Character+Uppercase.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +85,7 @@
 				26FA93251E67532400A5DF05 /* Routers */,
 				263781A51E65C66100BE6706 /* IO */,
 				263781A41E65B7A400BE6706 /* Generator */,
+				AF5A59D51E69BFD0009F531E /* Extensions */,
 				2637819D1E65B71500BE6706 /* main.swift */,
 				26FAFDA91E671B0600609139 /* README.md */,
 			);
@@ -116,6 +121,15 @@
 				26FA93231E67531800A5DF05 /* LaunchRouter.swift */,
 			);
 			name = Routers;
+			sourceTree = "<group>";
+		};
+		AF5A59D51E69BFD0009F531E /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				AF5A59D61E69BFDE009F531E /* String+CamelCase.swift */,
+				AF5A59D81E69C110009F531E /* Character+Uppercase.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -182,10 +196,12 @@
 				26FA93221E674F5C00A5DF05 /* DataRouter.swift in Sources */,
 				263781AB1E65C87000BE6706 /* JSONCollection.swift in Sources */,
 				263781B31E65DE9C00BE6706 /* StringInteractor.swift in Sources */,
+				AF5A59D71E69BFDE009F531E /* String+CamelCase.swift in Sources */,
 				263781AF1E65C97600BE6706 /* JSONInteractor.swift in Sources */,
 				263781A71E65C67500BE6706 /* IOWrapper.swift in Sources */,
 				26FAFDAC1E6721FE00609139 /* RecognizedArguments.swift in Sources */,
 				26FA93241E67531800A5DF05 /* LaunchRouter.swift in Sources */,
+				AF5A59D91E69C110009F531E /* Character+Uppercase.swift in Sources */,
 				263781A91E65C79400BE6706 /* JSONToSwiftError.swift in Sources */,
 				263781AD1E65C92700BE6706 /* JSONToSwift.swift in Sources */,
 			);

--- a/JSONSwiftGenerator/Character+Uppercase.swift
+++ b/JSONSwiftGenerator/Character+Uppercase.swift
@@ -1,0 +1,15 @@
+//
+//  Character+Uppercase.swift
+//  JSONSwiftGenerator
+//
+//  Created by Dan Turner on 3/3/17.
+//  Copyright © 2017 Bren. All rights reserved.
+//
+
+import Foundation
+
+extension Character {
+    var isUppercase: Bool {
+        return String(self) != String(self).lowercased()
+    }
+}

--- a/JSONSwiftGenerator/Generator/JSONCollection.swift
+++ b/JSONSwiftGenerator/Generator/JSONCollection.swift
@@ -81,8 +81,8 @@ extension JSONCollection: Collection {
 }
 
 extension JSONCollection {
-    var nonNullItems: [(key: String, value: Element)]  {
-        return contents.filter { $0.value is Array<Any> || $0.value is Dictionary<String, Any> || $0.value is String || $0.value is Double || $0.value is Bool }
+    var equatableItems: [(key: String, value: Element)]  {
+        return contents.filter { $0.value is Dictionary<String, Any> || $0.value is String || $0.value is Double || $0.value is Bool }
     }
     
     var arrayItems: [(key: String, value: Element)] {

--- a/JSONSwiftGenerator/Generator/JSONCollection.swift
+++ b/JSONSwiftGenerator/Generator/JSONCollection.swift
@@ -12,12 +12,12 @@ struct JSONCollection<Element> {
     fileprivate var contents: [String: Element] = [:]
     
     init(with key: String, element: Element) {
-        add(element, for: key)
+        add(element, for: key.camelCased)
     }
     
     init<S: Sequence>(_ sequence: S) where S.Iterator.Element == (key: String, value: Element) {
         for (key, value) in sequence {
-            add(value, for: key)
+            add(value, for: key.camelCased)
         }
     }
 }
@@ -121,18 +121,16 @@ extension JSONCollection {
     }
     
     var objectItemPropertyStrings: [String] {
-        return dictionaryItems.map { "let \($0.key): \($0.key.capitalized)JSON" }
+        return dictionaryItems.map { "let \($0.key): \($0.key.typeCamelCased)JSON" }
     }
     
     var objectItemInitStrings: [String] {
-        return dictionaryItems.map { "let \($0.key)Object = dictionary[\"\($0.key)\"] as? [String: Any] ?? [:]\nself.\($0.key) = \($0.key.capitalized)JSON(with: \($0.key)Object)" }
+        return dictionaryItems.map { "let \($0.key)Object = dictionary[\"\($0.key)\"] as? [String: Any] ?? [:]\nself.\($0.key) = \($0.key.typeCamelCased)JSON(with: \($0.key)Object)" }
     }
     
     var objectItemStructNames: [String] {
         return dictionaryItems.map { object in
-            let nameString = object.key.capitalized
-            let name = nameString.replacingOccurrences(of: " ", with: "")
-            return "\(name)JSON"
+            return "\(object.key.typeCamelCased)JSON"
         }
     }
     

--- a/JSONSwiftGenerator/Generator/JSONToSwift.swift
+++ b/JSONSwiftGenerator/Generator/JSONToSwift.swift
@@ -65,9 +65,9 @@ extension JSONToSwift {
         strings.append(contentsOf: [.close, .newLine, .close])
         if generateEquatable {
             strings.append(contentsOf: [.newLine, .newLine, .extensionName(name: rootObjectName), .newLine, .equatableFunctionDeclaration(name: rootObjectName), .newLine, .equatableFunctionStart])
-            for (index, key) in collection.nonNullItems.map({ $0.key }).enumerated() {
+            for (index, key) in collection.equatableItems.map({ $0.key }).enumerated() {
                 strings.append(.equatableComparison(name: key))
-                if index < collection.nonNullItems.count - 1 {
+                if index < collection.equatableItems.count - 1 {
                     strings.append(.andOperator)
                     strings.append(.newLine)
                 }

--- a/JSONSwiftGenerator/String+CamelCase.swift
+++ b/JSONSwiftGenerator/String+CamelCase.swift
@@ -1,0 +1,58 @@
+//
+//  String+CamelCase.swift
+//  JSONSwiftGenerator
+//
+//  Created by Dan Turner on 3/3/17.
+//  Copyright © 2017 Bren. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    var camelCased: String {
+        if let existingFirstCharacter = characters.first, existingFirstCharacter.isUppercase {
+            return camelCasedUppercase()
+        }
+        else {
+            return camelCasedLowercase()
+        }
+    }
+    
+    var typeCamelCased: String {
+        let camelCasedString = camelCased
+        let firstCharacter = camelCasedString.substring(to: index(startIndex, offsetBy: 1)).uppercased()
+        let restOfString = String(camelCasedString.characters.dropFirst())
+        
+        return "\(firstCharacter)\(restOfString)"
+    }
+    
+    private func camelCasedLowercase() -> String {
+        let firstCharacter, restOfString: String
+        
+        if characters.contains(" ") {
+            firstCharacter = substring(to: index(startIndex, offsetBy: 1))
+            let capitalizedWithoutSpaces = capitalized.replacingOccurrences(of: " ", with: "")
+            restOfString = String(capitalizedWithoutSpaces.characters.dropFirst())
+        } else {
+            firstCharacter = substring(to: lowercased().index(startIndex, offsetBy: 1))
+            restOfString = String(characters.dropFirst())
+        }
+        
+        return "\(firstCharacter)\(restOfString)"
+    }
+    
+    private func camelCasedUppercase() -> String {
+        let firstCharacter, restOfString: String
+        
+        if characters.contains(" ") {
+            firstCharacter = lowercased().substring(to: index(startIndex, offsetBy: 1))
+            let capitalizedWithoutSpaces = capitalized.replacingOccurrences(of: " ", with: "")
+            restOfString = String(capitalizedWithoutSpaces.characters.dropFirst())
+        } else {
+            firstCharacter = substring(to: index(startIndex, offsetBy: 1))
+            restOfString = String(characters.dropFirst())
+        }
+        
+        return "\(firstCharacter)\(restOfString)"
+    }
+}


### PR DESCRIPTION
- automatically remove spaces and use camelCase and TypeCase for property names and struct names respectively
- exclude [Any] arrays from Equatable implementation